### PR TITLE
Erase support (transparent background only)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2018 Eric Prokop und Nils Wieler Hard- und Softwareentwicklung GbR
+Copyright 2018 Eric Prokop und Nils Wieler Hard- und Softwareentwicklung GbR und Tomasz Marzeion
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/lib/painter.dart
+++ b/lib/painter.dart
@@ -191,6 +191,8 @@ class PainterController extends ChangeNotifier{
     _pathHistory=new _PathHistory();
   }
 
+  // setter for erase mode.
+  // Note: Works only for transparent background
   bool get eraseMode => _eraseMode;
   set eraseMode(bool enabled) {
     _eraseMode = enabled;

--- a/lib/painter.dart
+++ b/lib/painter.dart
@@ -18,14 +18,12 @@ class Painter extends StatefulWidget {
 
 class _PainterState extends State<Painter> {
 
-  bool _eraseMode;
   bool _finished;
 
   @override
   void initState() {
     super.initState();
     _finished=false;
-    _eraseMode=false;
     widget.painterController._widgetFinish=_finish;
   }
 

--- a/lib/painter.dart
+++ b/lib/painter.dart
@@ -18,12 +18,14 @@ class Painter extends StatefulWidget {
 
 class _PainterState extends State<Painter> {
 
+  bool _eraseMode;
   bool _finished;
 
   @override
   void initState() {
     super.initState();
     _finished=false;
+    _eraseMode=false;
     widget.painterController._widgetFinish=_finish;
   }
 
@@ -147,10 +149,12 @@ class _PathHistory{
   }
 
   void draw(Canvas canvas,Size size){
+    canvas.saveLayer(Offset.zero & size, Paint());
     canvas.drawRect(new Rect.fromLTWH(0.0, 0.0, size.width, size.height), _backgroundPaint);
     for(MapEntry<Path,Paint> path in _paths){
       canvas.drawPath(path.key,path.value);
     }
+    canvas.restore();
   }
 }
 
@@ -176,6 +180,7 @@ class PictureDetails{
 class PainterController extends ChangeNotifier{
   Color _drawColor=new Color.fromARGB(255, 0, 0, 0);
   Color _backgroundColor=new Color.fromARGB(255, 255, 255, 255);
+  bool _eraseMode=false;
 
   double _thickness=1.0;
   PictureDetails _cached;
@@ -184,6 +189,12 @@ class PainterController extends ChangeNotifier{
 
   PainterController(){
     _pathHistory=new _PathHistory();
+  }
+
+  bool get eraseMode => _eraseMode;
+  set eraseMode(bool enabled) {
+    _eraseMode = enabled;
+    _updatePaint();
   }
 
   Color get drawColor => _drawColor;
@@ -206,7 +217,12 @@ class PainterController extends ChangeNotifier{
 
   void _updatePaint(){
     Paint paint=new Paint();
-    paint.color=drawColor;
+    if (_eraseMode) {
+      paint.color=Color.fromARGB(0, 255, 0, 0);
+      paint.blendMode = BlendMode.clear;
+    } else {
+      paint.color=drawColor;
+    }
     paint.style=PaintingStyle.stroke;
     paint.strokeWidth=thickness;
     _pathHistory.currentPaint=paint;


### PR DESCRIPTION
Here is PR with code change that allows user to set erase mode.
Set `controller.eraseMode = true` for erase mode.

**Note: This works only for transparent background. If You want this to work with colored background, further code changes are needed. My suggestion is moving background to another canvas, by simply using Stack and inserting simple box view below painter layer.**